### PR TITLE
Add ESP32 compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,11 +6,11 @@
         "type": "git",
         "url": "https://github.com/xoseperez/debounceevent"
     },
-    "version": "2.0.5",
+    "version": "2.0.6",
     "license": "GPL-3.0",
     "exclude": "tests",
     "frameworks": "arduino",
-    "platforms": ["atmelavr","espressif8266"],
+    "platforms": ["atmelavr","espressif8266","espressif32"],
     "dependencies": [
     ],
     "authors": {

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=DebounceEvent
-version=2.0.5
+version=2.0.6
 author=Xose Pérez <xose.perez@gmail.com>
 maintainer=Xose Pérez <xose.perez@gmail.com>
 sentence=Simple push button and toggle switch debounce library that reports number of clicks and length
 paragraph=
 category=Signal Input/Output
 url=https://github.com/xoseperez/debounceevent
-architectures=avr,esp8266
+architectures=avr,esp8266,esp32
 includes=DebounceEvent.h

--- a/src/DebounceEvent.h
+++ b/src/DebounceEvent.h
@@ -22,7 +22,7 @@
 #ifndef _DEBOUNCE_EVENT_h
 #define _DEBOUNCE_EVENT_h
 
-#ifdef ESP8266
+#if defined ESP8266 | defined ESP32
 #include <functional>
 #define DEBOUNCE_EVENT_CALLBACK_SIGNATURE std::function<void(uint8_t pin, uint8_t event, uint8_t count, uint16_t length)> callback
 #else


### PR DESCRIPTION
- Include ESP32 as supported platform
- Add ESP32 to `functional` callback definition to support class methods using `std::bind()`