### PR TITLE
Add arduino_ci unit testing on pull requests

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,0 +1,8 @@
+unittest:
+  platforms:
+    - leonardo
+
+compile:
+  platforms:
+   - leonardo
+   - esp8266

--- a/.github/workflows/arduino_test_runner.yml
+++ b/.github/workflows/arduino_test_runner.yml
@@ -1,0 +1,9 @@
+---
+name: Arduino_CI
+on: [push, pull_request]
+jobs:
+  arduino_ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Arduino-CI/action@v0.1.2

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/*
 
 # Credentials
 credentials.h
+
+# arduino CI unit tests
+*.bin

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Simple push button and toggle switch debounce library for AVR and ESP8266 platfo
 
 [![version](https://img.shields.io/badge/version-2.0.5-brightgreen.svg)](CHANGELOG.md)
 [![license](https://img.shields.io/badge/license-LGPL--3.0-orange.svg)](LICENSE)
+[![Arduino CI](https://github.com/xoseperez/debounceevent/workflows/Arduino_CI/badge.svg)](https://github.com/marketplace/actions/arduino_ci)
 <br />
 [![donate](https://img.shields.io/badge/donate-PayPal-blue.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=xose%2eperez%40gmail%2ecom&lc=US&no_note=0&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHostedGuest)
 [![twitter](https://img.shields.io/twitter/follow/xoseperez.svg?style=social)](https://twitter.com/intent/follow?screen_name=xoseperez)

--- a/test/debouncing.cpp
+++ b/test/debouncing.cpp
@@ -1,0 +1,68 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+#include <DebounceEvent.h>
+
+const int buttonPin               = 4;
+const unsigned long debounceDelay = 50;
+const unsigned long repeatDelay   = 500;
+DebounceEvent* button;
+
+// Declare state and reset it for each test
+GodmodeState* state = GODMODE();
+unittest_setup() {
+  state->reset();
+}
+
+unittest(starts_with_no_event) {
+  DebounceEvent button(buttonPin,
+                       BUTTON_PUSHBUTTON,
+                       debounceDelay,
+                       repeatDelay);
+  unsigned int event;
+
+  state->micros                = 0;
+  event = button.loop();
+  assertEqual(EVENT_NONE, event);
+  assertEqual(0, state->micros);            // no running the clock
+  assertEqual(0, button.getEventCount());
+  //assertEqual(0, button.getEventLength()); uninitialized
+}
+
+unittest(debounce_waits_for_settling) {
+  DebounceEvent button(buttonPin,
+                       BUTTON_PUSHBUTTON,
+                       debounceDelay,
+                       repeatDelay);
+  unsigned int event;
+
+  state->micros                = 2000;
+  state->digitalPin[buttonPin] = HIGH;      // simulate press
+  event = button.loop();
+  assertEqual(EVENT_PRESSED, event);
+  assertEqual(2000 + (debounceDelay * 1000), state->micros);
+
+  state->micros                = 60000;
+  event = button.loop();
+  assertEqual(EVENT_NONE, event);
+  assertEqual(60000, state->micros);
+
+  state->micros                = 100000;
+  state->digitalPin[buttonPin] = LOW;       // simulate release
+  event = button.loop();
+  assertEqual(EVENT_NONE, event);
+  assertEqual(100000 + (debounceDelay * 1000), state->micros);
+  assertEqual(150000, state->micros);
+
+  state->micros                = 552999;    // boundary condition, not sure why this value
+  event = button.loop();
+  assertEqual(EVENT_NONE, event);
+
+  state->micros                = 553000;    // event sent 403ms after pin went low.  math???
+  event = button.loop();
+  assertEqual(EVENT_RELEASED, event);
+  assertEqual(1, button.getEventCount());
+  assertEqual(98, button.getEventLength());
+}
+
+
+unittest_main()


### PR DESCRIPTION
For your consideration, a proof of concept unit test implementation that runs via GitHub actions on pull requests.

I'm the author of the [`arduino_ci` GitHub action](https://github.com/marketplace/actions/arduino_ci), and the topic came up of whether a unit testing framework with mocked hardware could properly simulate "real world" hardware state (indeterminate input) -- debounce in particular was mentioned.

I wrote these tests only to satisfy my own curiosity; I'm not insistent that it get merged, just offering the work already done in case it is of interest.